### PR TITLE
:prep-tasks default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ example, to automatically call `make` before running tasks, add this to your
 `project.clj` map:
 
 ```clj
-:prep-tasks [["shell" "make"]]
+:prep-tasks [["shell" "make"] "javac" "compile"]
 ```
 
 ### OS-specific subprocess call
@@ -51,7 +51,7 @@ such a task, a setup like this should suffice:
 ```clj
 (defproject ...
   ...
-  :prep-tasks [["shell" "foo" "arg1" "arg2"] "javac" "compile" ]
+  :prep-tasks [["shell" "foo" "arg1" "arg2"] "javac" "compile"]
   :shell {:commands {"foo" {:windows "bar"}}})
 ```
 


### PR DESCRIPTION
I had to discover the default values for :prep-tasks and then append them to your usage examples before lein could invoke the shell and build properly. Maybe these changes will help others.
