### PR TITLE
Provide vector of commands for OS-specific calls

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -222,6 +222,15 @@ project.
 As may be evident, this replacement option is only possible for specific
 commands, and is not something you can set in general.
 
+If you need to run several commands on one OS to achieve equivalent results
+on other platforms, then you can provide multiple commands in a vector:
+
+```clj
+(defproject ...
+  ...
+  :shell {:commands {"foo" {:windows ["bar" "baz" "bat"]}}})
+```
+
 The (currently) different detectable oses are `:freebsd`, `:linux`, `:macosx`,
 `:openbsd`, `:solaris` and `:windows`, but this may automatically increase with
 newer leiningen releases.

--- a/src/leiningen/shell.clj
+++ b/src/leiningen/shell.clj
@@ -38,10 +38,10 @@
         os (eval/get-os)]
     (if-let [os-cmd (or (get-in project [:shell :commands command os])
                         (get-in project [:shell :commands command :default-command]))]
-      (do
+      (let [normalized-cmd (if (string? os-cmd) [os-cmd] os-cmd)]
         (main/debug (format "[shell] Replacing command %s with %s. (os is %s)"
-                            command os-cmd os))
-        (cons os-cmd (rest cmd)))
+                            command normalized-cmd os))
+        (concat normalized-cmd (rest cmd)))
       cmd)))
 
 (defn- shell-with-project [project cmd]


### PR DESCRIPTION
Allows user to provide OS specific vector of commands which will be
substituted for the single command provided in [:shell :commands].
Add documentation on its usage.

Fixes #18