### PR TITLE
Fix Leiningen 2.12 get-os deprecation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # lein-shell changelog
 
+## 1.0.0 (unreleased)
+
+* Migrated to `utils/get-os`, resolving the deprecation warning under Leiningen 2.12.
+
 ## 0.5.0 [`tag`][0.5.0-tag]
 
 * Fixed a bug where non-string were not converted to strings before sent to the

--- a/src/leiningen/shell.clj
+++ b/src/leiningen/shell.clj
@@ -1,7 +1,5 @@
 (ns leiningen.shell
-  (:require [clojure.java.io :as io]
-            [clojure.string :as s]
-            [leiningen.core.eval :as eval]
+  (:require [leiningen.core.eval :as eval]
             [leiningen.core.main :as main]
             [leiningen.core.utils :as utils]))
 

--- a/src/leiningen/shell.clj
+++ b/src/leiningen/shell.clj
@@ -139,7 +139,7 @@
   version if there is one."
   [project cmd]
   (let [command (first cmd)
-        os (eval/get-os)]
+        os (utils/get-os)]
     (if-let [os-cmd (or (get-in project [:shell :commands command os])
                         (get-in project [:shell :commands command :default-command]))]
       (let [normalized-cmd (if (string? os-cmd) [os-cmd] os-cmd)]


### PR DESCRIPTION
`leiningen.core.eval/get-os` became `^:deprecated` in Leiningen 2.12.0 — it now just re-exports `leiningen.core.utils/get-os`. This switches to the canonical var, which is behavior-identical (the old name is a deprecated alias) and also makes the already-present `leiningen.core.utils` require meaningful.

Also drops two unused requires (`clojure.java.io`, `clojure.string`) and adds a CHANGES.md entry.

No behavior change; `lein test` passes.