### PR TITLE
Add GitHub Actions CI (Leiningen x JDK matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: JDK ${{ matrix.jdk }} / Leiningen ${{ matrix.lein }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ['8', '17', '21']
+        lein: ['2.9.10', '2.11.2', '2.12.0']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+
+      - name: Set up Leiningen ${{ matrix.lein }}
+        uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          lein: ${{ matrix.lein }}
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-lein${{ matrix.lein }}-${{ hashFiles('project.clj') }}
+          restore-keys: ${{ runner.os }}-m2-lein${{ matrix.lein }}-
+
+      - name: Run tests
+        run: lein test


### PR DESCRIPTION
No CI existed. Adds an Actions workflow testing Leiningen 2.9/2.11/2.12 × JDK 8/17/21, with `fail-fast: false` so each cell reports independently and you get an empirical compatibility grid on every push.

Green across all 9 cells on my fork: https://github.com/jsavyasachi/lein-shell/actions/runs/26734444298